### PR TITLE
pc - add storybook to github workflow to build site

### DIFF
--- a/.github/workflows/38_gh_pages_deploy_frontend.yml
+++ b/.github/workflows/38_gh_pages_deploy_frontend.yml
@@ -31,37 +31,15 @@ jobs:
       run: npm run build
       working-directory: ./frontend
 
+    - name: Build Storybook
+        working-directory: ./frontend
+        run: | # Install npm packages and build the Storybook files
+          mkdir -p docs-build
+          npm run build-storybook
+          mv docs-build build/docs
+
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: ./frontend/build # The folder the action should deploy.
         branch: gh-pages
-
-
-    # - name: Upload production-ready build files
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: production-files
-    #     path: ./frontend/build
-
-  # deploy:
-  #   name: Deploy
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   if: github.ref == 'refs/heads/main'
-    
-  #   steps:
-  #   - name: Download artifact
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #       name: production-files
-  #       path: ./frontend/build
-
-  #   - name: Deploy to gh-pages
-  #     uses: peaceiris/actions-gh-pages@v3
-  #     with:
-  #       github_token: ${{ secrets.GITHUB_TOKEN }}
-  #       publish_dir: ./frontend/build
-   
-  
-    


### PR DESCRIPTION
In this PR, we modify the GitHub Actions script that publishes the site to GitHub Pages to incorporate publishing the storybook as well under the /docs subdirectory.

